### PR TITLE
Create enforce-branch-naming.yml

### DIFF
--- a/.github/workflows/enforce-branch-naming.yml
+++ b/.github/workflows/enforce-branch-naming.yml
@@ -1,0 +1,20 @@
+name: Enforce Branch Naming
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name
+        run: |
+          BRANCH_NAME=${{ github.event.pull_request.head.ref }}
+          REQUIRED_PREFIX="feature/"  # Change this to your desired prefix
+          if [[ ! $BRANCH_NAME =~ ^$REQUIRED_PREFIX ]]; then
+            echo "Error: Branch name '$BRANCH_NAME' does not start with '$REQUIRED_PREFIX'."
+            exit 1
+          else
+            echo "Branch name '$BRANCH_NAME' is valid."
+          fi


### PR DESCRIPTION
Require user to prefix their branch name with their username to prevent over-writing main with a test commit.